### PR TITLE
Re-export quick-xml to prevent the need to import quick-xml as an end-user

### DIFF
--- a/test_suite/Cargo.toml
+++ b/test_suite/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 xavier = { path = "../xavier" }
-quick-xml = "0.31.0"
+quick-xml = "0.37.5"
 

--- a/xavier/Cargo.toml
+++ b/xavier/Cargo.toml
@@ -12,7 +12,7 @@ readme="../README.md"
 keywords = ["xavier", "xml"]
 
 [dependencies]
-quick-xml = "0.31.0"
+quick-xml = "0.37.5"
 xavier-derive = { version = "0.1.4", path = "../xavier_derive", optional = false }
 xavier-internal = { version = "0.1.4", path = "../xavier_internal", optional = false }
 

--- a/xavier/src/lib.rs
+++ b/xavier/src/lib.rs
@@ -19,6 +19,8 @@ pub use xavier_internal::instructions;
 pub use xavier_internal::serialize;
 pub use xavier_internal::deserialize;
 
+pub use ::quick_xml;
+
 pub fn from_obj<T: XmlSerializable>(obj: &T) -> String {
     obj.to_xml(true)
 }

--- a/xavier_derive/src/deserialize/parser/complex/stream.rs
+++ b/xavier_derive/src/deserialize/parser/complex/stream.rs
@@ -44,24 +44,24 @@ impl XmlComplex {
             loop {
                 match reader.read_event() {
                     Err(error) =>  { return Err(PError::new(&format!("Error at position {}: {:?}", reader.buffer_position(), error))) },
-                    Ok(quick_xml::events::Event::Start(event)) => {
+                    Ok(::xavier::quick_xml::events::Event::Start(event)) => {
                         let xa_tag_name = String::from_utf8(event.name().0.to_vec())?;
                         if #debug { println!("[{}.{}.Start] Start Event", #xml_tag_name, xa_tag_name); }
                         #(#field_setters)*
                         #(#sibling_setters)*
                     },
-                    Ok(quick_xml::events::Event::Empty(event)) => {
+                    Ok(::xavier::quick_xml::events::Event::Empty(event)) => {
                         let xa_tag_name = String::from_utf8(event.name().0.to_vec())?;
                         #(#field_setters)*
                         #(#sibling_setters)*
                     },
-                    Ok(quick_xml::events::Event::Text(event)) => {
+                    Ok(::xavier::quick_xml::events::Event::Text(event)) => {
                         #(#value_setters)*
                     },
-                    Ok(quick_xml::events::Event::CData(event)) => {
+                    Ok(::xavier::quick_xml::events::Event::CData(event)) => {
                         #(#value_setters)*
                     },
-                    Ok(quick_xml::events::Event::End(event)) => {
+                    Ok(::xavier::quick_xml::events::Event::End(event)) => {
                         if String::from_utf8(event.name().0.to_vec())? == #xml_tag_name {
                             if #debug { println!("[{}.End] End Event ", #xml_tag_name); }
                             #constructor
@@ -69,11 +69,11 @@ impl XmlComplex {
                             if #debug { println!("[{}.{}.End] End Event ", #xml_tag_name, String::from_utf8(event.name().0.to_vec())?); }
                         }
                     },
-                    Ok(quick_xml::events::Event::Eof) => { break },
-                    Ok(quick_xml::events::Event::Decl(_)) => {},
-                    Ok(quick_xml::events::Event::PI(_)) => {},
-                    Ok(quick_xml::events::Event::DocType(_)) => {},
-                    Ok(quick_xml::events::Event::Comment(_)) => {}
+                    Ok(::xavier::quick_xml::events::Event::Eof) => { break },
+                    Ok(::xavier::quick_xml::events::Event::Decl(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::PI(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::DocType(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::Comment(_)) => {}
                 };
             };
             Err(xavier::PError::new("Error root not found"))

--- a/xavier_derive/src/deserialize/parser/enums.rs
+++ b/xavier_derive/src/deserialize/parser/enums.rs
@@ -10,16 +10,16 @@ impl XmlEnum {
             loop {
                 match reader.read_event() {
                     Err(error) =>  { return Err(PError::new(&format!("Error at position {}: {:?}", reader.buffer_position(), error))) },
-                    Ok(quick_xml::events::Event::Eof) => { },
-                    Ok(quick_xml::events::Event::Start(_)) => {},
-                    Ok(quick_xml::events::Event::End(_)) => {},
-                    Ok(quick_xml::events::Event::Empty(_)) => {},
-                    Ok(quick_xml::events::Event::Comment(_)) => {},
-                    Ok(quick_xml::events::Event::Text(event)) => { return Ok(String::from_utf8(event.to_vec())?.parse()?); },
-                    Ok(quick_xml::events::Event::CData(event)) => { return Ok(String::from_utf8(event.to_vec())?.parse()?); },
-                    Ok(quick_xml::events::Event::Decl(_)) => {},
-                    Ok(quick_xml::events::Event::PI(_)) => {},
-                    Ok(quick_xml::events::Event::DocType(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::Eof) => { },
+                    Ok(::xavier::quick_xml::events::Event::Start(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::End(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::Empty(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::Comment(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::Text(event)) => { return Ok(String::from_utf8(event.to_vec())?.parse()?); },
+                    Ok(::xavier::quick_xml::events::Event::CData(event)) => { return Ok(String::from_utf8(event.to_vec())?.parse()?); },
+                    Ok(::xavier::quick_xml::events::Event::Decl(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::PI(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::DocType(_)) => {},
                 }
             }
         }

--- a/xavier_derive/src/deserialize/parser/simple.rs
+++ b/xavier_derive/src/deserialize/parser/simple.rs
@@ -11,16 +11,16 @@ impl XmlSimpleTag {
             loop {
                 match reader.read_event() {
                     Err(error) =>  { return Err(PError::new(&format!("Error at position {}: {:?}", reader.buffer_position(), error))) },
-                    Ok(quick_xml::events::Event::Eof) => { },
-                    Ok(quick_xml::events::Event::Start(_)) => {},
-                    Ok(quick_xml::events::Event::End(_)) => {},
-                    Ok(quick_xml::events::Event::Empty(_)) => {},
-                    Ok(quick_xml::events::Event::Comment(_)) => {},
-                    Ok(quick_xml::events::Event::Text(event)) => { return Ok(Self(String::from_utf8(event.to_vec())?.parse()?)); },
-                    Ok(quick_xml::events::Event::CData(event)) => { return Ok(Self(String::from_utf8(event.to_vec())?.parse()?)); },
-                    Ok(quick_xml::events::Event::Decl(_)) => {},
-                    Ok(quick_xml::events::Event::PI(_)) => {},
-                    Ok(quick_xml::events::Event::DocType(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::Eof) => { },
+                    Ok(::xavier::quick_xml::events::Event::Start(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::End(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::Empty(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::Comment(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::Text(event)) => { return Ok(Self(String::from_utf8(event.to_vec())?.parse()?)); },
+                    Ok(::xavier::quick_xml::events::Event::CData(event)) => { return Ok(Self(String::from_utf8(event.to_vec())?.parse()?)); },
+                    Ok(::xavier::quick_xml::events::Event::Decl(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::PI(_)) => {},
+                    Ok(::xavier::quick_xml::events::Event::DocType(_)) => {},
                 }
             }
         }

--- a/xavier_derive/src/deserialize/proc_macro.rs
+++ b/xavier_derive/src/deserialize/proc_macro.rs
@@ -33,7 +33,7 @@ pub fn impl_xml_deserializable(input: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         impl #impl_generics xavier::deserialize::macro_trait::XmlDeserializable for #object_name #ty_generics #where_clause {
-            fn from_xml(mut reader: &mut quick_xml::Reader<&[u8]>, start_event: Option<&quick_xml::events::BytesStart>) -> Result<Self, xavier::PError> {
+            fn from_xml(mut reader: &mut ::xavier::quick_xml::Reader<&[u8]>, start_event: Option<&::xavier::quick_xml::events::BytesStart>) -> Result<Self, xavier::PError> {
                 #xml_code
             }
             fn inner_name() -> Option<String> {

--- a/xavier_internal/Cargo.toml
+++ b/xavier_internal/Cargo.toml
@@ -12,5 +12,5 @@ readme="../README.md"
 keywords = ["xavier", "xml"]
 
 [dependencies]
-quick-xml = "0.31.0"
+quick-xml = "0.37.5"
 html-escape = "0.2.13"


### PR DESCRIPTION
I noticed that it is currently necessary to import `quick-xml` yourself when using the derive-proc-macros.

This change prevents that by publicly exporting `quick-xml` in the `xavier` crate, to which `xavier-derive` can then refer.

The `quick-xml` has been bumped as well.